### PR TITLE
update unexpected to 10.27.0 and use expect.child

### DIFF
--- a/lib/unexpected-koa.js
+++ b/lib/unexpected-koa.js
@@ -17,6 +17,7 @@ module.exports = {
     name: 'unexpected-koa',
     version: require('../package.json').version,
     installInto: function (expect) {
+        expect = expect.child();
         expect.use(require('unexpected-messy'));
 
         expect.addType({
@@ -30,7 +31,7 @@ module.exports = {
             }
         });
 
-        expect.addAssertion('<any> to yield exchange <object>', function (expect, subject, value) {
+        expect.exportAssertion('<any> to yield exchange <object>', function (expect, subject, value) {
             if (typeof subject !== 'function' && !(subject) instanceof Koa) {
                 console.log('subject must be either a function or Koa');
             }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "koa-router": "7.0.1",
     "mocha": "3.1.2",
     "nyc": "8.3.2",
-    "unexpected": "10.18.1"
+    "unexpected": "10.27.0"
   },
   "dependencies": {
     "unexpected-messy": "^6.2.0"


### PR DESCRIPTION
This module had unexpected-messy as a dependency already, so it
would potentially have caused compatibility problems before this
child change.